### PR TITLE
Change the base directory to /storm to store logs and state files in …

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ The main configuration variables are located at the top of `lora_app.py`:
 - `SITE_ID`: The identifier for the data site (e.g., "Hutsonville"). This is used to construct the CSV data URL.
 - `STORM_HOST`: The IP address or hostname of the Storm3 device.
 - `CSV_URL`: The full URL to the CSV data file, constructed from `STORM_HOST` and `SITE_ID`.
-- `BASE_DIR`: The base directory (`~/storm/lora_app`) where logs and state files are stored.
+- `BASE_DIR`: The base directory (`/storm`) where logs and state files are stored.
 
 ## Directory Structure
 
-The application creates the following directory structure in the user's home directory:
+The application creates the following directory structure:
 
-- `~/storm/lora_app/`
+- `/storm/`
   - `logs/`: Contains log files for both transmitter and receiver, as well as any received data.
     - `lora_tx.log`: Log for the transmitter.
     - `lora_rx.log`: Log for the receiver.

--- a/lora_app.py
+++ b/lora_app.py
@@ -52,7 +52,7 @@ CSV_URL    = f"http://{STORM_HOST}/data/{SITE_ID}.csv"
 # ---------------------------
 # Paths & logging
 # ---------------------------
-BASE_DIR  = os.path.expanduser("~/storm/lora_app")
+BASE_DIR  = "/storm"
 LOG_DIR   = os.path.join(BASE_DIR, "logs")
 STATE_DIR = os.path.join(BASE_DIR, "state")
 os.makedirs(LOG_DIR, exist_ok=True)


### PR DESCRIPTION
…/storm/logs and /storm/state respectively.

The `BASE_DIR` variable in `lora_app.py` was changed from `os.path.expanduser("~/storm/lora_app")` to `"/storm"`.

The `README.md` file has been updated to reflect the new directory structure.