### PR TITLE
feat: Implement packet-shortening plan for LoRa JSON payload

### DIFF
--- a/lora_app.py
+++ b/lora_app.py
@@ -43,6 +43,57 @@ from typing import Optional, Tuple
 from threading import Timer, Lock, Event
 
 # ---------------------------
+# CRC-16/MODBUS calculation
+# ---------------------------
+# Using a pre-calculated table for efficiency, as recommended.
+# Source: https://www.digi.com/resources/documentation/digidocs/90001537/references/r_python_crc16_modbus.htm
+CRC16_MODBUS_TABLE = (
+    0x0000, 0xC0C1, 0xC181, 0x0140, 0xC301, 0x03C0, 0x0280, 0xC241,
+    0xC601, 0x06C0, 0x0780, 0xC741, 0x0500, 0xC5C1, 0xC481, 0x0440,
+    0xCC01, 0x0CC0, 0x0D80, 0xCD41, 0x0F00, 0xCFC1, 0xCE81, 0x0E40,
+    0x0A00, 0xCAC1, 0xCB81, 0x0B40, 0xC901, 0x09C0, 0x0880, 0xC841,
+    0xD801, 0x18C0, 0x1980, 0xD941, 0x1B00, 0xDBC1, 0xDA81, 0x1A40,
+    0x1E00, 0xDEC1, 0xDF81, 0x1F40, 0xDD01, 0x1DC0, 0x1C80, 0xDC41,
+    0x1400, 0xD4C1, 0xD581, 0x1540, 0xD701, 0x17C0, 0x1680, 0xD641,
+    0xD201, 0x12C0, 0x1380, 0xD341, 0x1100, 0xD1C1, 0xD081, 0x1040,
+    0xF001, 0x30C0, 0x3180, 0xF141, 0x3300, 0xF3C1, 0xF281, 0x3240,
+    0x3600, 0xF6C1, 0xF781, 0x3740, 0xF501, 0x35C0, 0x3480, 0xF441,
+    0x3C00, 0xFCC1, 0xFD81, 0x3D40, 0xFF01, 0x3FC0, 0x3E80, 0xFE41,
+    0xFA01, 0x3AC0, 0x3B80, 0xFB41, 0x3900, 0xF9C1, 0xF881, 0x3840,
+    0x2800, 0xE8C1, 0xE981, 0x2940, 0xEB01, 0x2BC0, 0x2A80, 0xEA41,
+    0xEE01, 0x2EC0, 0x2F80, 0xEF41, 0x2D00, 0xEDC1, 0xEC81, 0x2C40,
+    0xE401, 0x24C0, 0x2580, 0xE541, 0x2700, 0xE7C1, 0xE681, 0x2640,
+    0x2200, 0xE2C1, 0xE381, 0x2340, 0xE101, 0x21C0, 0x2080, 0xE041,
+    0xA001, 0x60C0, 0x6180, 0xA141, 0x6300, 0xA3C1, 0xA281, 0x6240,
+    0x6600, 0xA6C1, 0xA781, 0x6740, 0xA501, 0x65C0, 0x6480, 0xA441,
+    0x6C00, 0xACC1, 0xAD81, 0x6D40, 0xAF01, 0x6FC0, 0x6E80, 0xAE41,
+    0xAA01, 0x6AC0, 0x6B80, 0xAB41, 0x6900, 0xA9C1, 0xA881, 0x6840,
+    0x7800, 0xB8C1, 0xB981, 0x7940, 0xBB01, 0x7BC0, 0x7A80, 0xBA41,
+    0xBE01, 0x7EC0, 0x7F80, 0xBF41, 0x7D00, 0xBDC1, 0xBC81, 0x7C40,
+    0xB401, 0x74C0, 0x7580, 0xB541, 0x7700, 0xB7C1, 0xB681, 0x7640,
+    0x7200, 0xB2C1, 0xB381, 0x7340, 0xB101, 0x71C0, 0x7080, 0xB041,
+    0x5000, 0x90C1, 0x9181, 0x5140, 0x9301, 0x53C0, 0x5280, 0x9241,
+    0x9601, 0x56C0, 0x5780, 0x9741, 0x5500, 0x95C1, 0x9481, 0x5440,
+    0x9C01, 0x5CC0, 0x5D80, 0x9D41, 0x5F00, 0x9FC1, 0x9E81, 0x5E40,
+    0x5A00, 0x9AC1, 0x9B81, 0x5B40, 0x9901, 0x59C0, 0x5880, 0x9841,
+    0x8801, 0x48C0, 0x4980, 0x8941, 0x4B00, 0x8BC1, 0x8A81, 0x4A40,
+    0x4E00, 0x8EC1, 0x8F81, 0x4F40, 0x8D01, 0x4DC0, 0x4C80, 0x8C41,
+    0x4400, 0x84C1, 0x8581, 0x4540, 0x8701, 0x47C0, 0x4680, 0x8641,
+    0x8201, 0x42C0, 0x4380, 0x8341, 0x4100, 0x81C1, 0x8081, 0x4040,
+)
+
+def crc16_modbus(data: bytes) -> str:
+    """
+    Calculates the CRC-16/MODBUS checksum for a byte string.
+    Returns a 4-character uppercase hexadecimal string.
+    """
+    crc = 0xFFFF  # Initial value for MODBUS
+    for byte in data:
+        crc = (crc >> 8) ^ CRC16_MODBUS_TABLE[(crc ^ byte) & 0xFF]
+    # Return as 4-char hex string (e.g., "7F3C")
+    return f"{crc:04X}"
+
+# ---------------------------
 # Storm3 CSV configuration
 # ---------------------------
 SITE_ID    = "Hutsonville"
@@ -350,65 +401,81 @@ class LoRaNode:
                     self.stats[stat_type] += 1
 
     def create_packet(self, packet_type: str, seq_num: int, **kwargs):
-        """Create packet with checksum using shortened JSON format"""
+        """Create packet with checksum using the new shortened JSON format"""
         if packet_type == 'STORM_DATA':
+            # Combine date and time into the compact "YYMMDDHHmm" format
+            csv_date_str = kwargs.get('csv_date', '')  # "MM/DD/YYYY"
+            csv_time_str = kwargs.get('csv_time', '')  # "HH:MM:SS"
+            compact_ts = ""
+            try:
+                # Parse "MM/DD/YYYY HH:MM:SS"
+                dt_obj = datetime.strptime(f"{csv_date_str} {csv_time_str}", "%m/%d/%Y %H:%M:%S")
+                compact_ts = dt_obj.strftime("%y%m%d%H%M")
+            except ValueError:
+                self.log_and_print(f"Could not parse date/time: {csv_date_str} {csv_time_str}")
+
+            # Safely convert river and rain to floats, with rounding
+            try:
+                river_val = round(float(kwargs.get('riverstage', '0')), 3)
+            except (ValueError, TypeError):
+                river_val = 0.0
+            try:
+                rain_val = round(float(kwargs.get('rain_gauge', '0')), 2)
+            except (ValueError, TypeError):
+                rain_val = 0.0
+
             packet_data = {
-                'seq': seq_num,
-                'src_addr': self.addr,
-                'dst_addr': self.target_addr,
-                'ts': datetime.now().strftime('%H:%M:%S'),  # shortened timestamp
-                'T': round(kwargs.get('board_temp_c', 0), 1),  # board_temp_c -> T
-                'c_date': kwargs.get('csv_date'),  # csv_date -> c_date
-                'c_time': kwargs.get('csv_time'),  # csv_time -> c_time
-                'd': kwargs.get('riverstage'),  # riverstage -> d
-                'r': kwargs.get('rain_gauge')   # rain_gauge -> r
+                's': seq_num,
+                't': compact_ts,
+                'd': river_val,
+                'r': rain_val,
+                'T': round(kwargs.get('board_temp_c', 0), 1)
             }
         elif packet_type == 'ACK':
             packet_data = {
-                'seq': seq_num,
-                'src_addr': self.addr,
-                'dst_addr': self.target_addr,
-                'ts': datetime.now().strftime('%H:%M:%S'),  # shortened timestamp
-                'ack': True
+                's': seq_num,
+                'a': 1 # 'ack' -> 'a' for short
             }
-        else:
-            # Fallback
-            packet_data = {
-                'seq': seq_num,
-                'src_addr': self.addr,
-                'dst_addr': self.target_addr,
-                'ts': datetime.now().strftime('%H:%M:%S')
-            }
+        else: # Fallback for unknown types
+            packet_data = {'s': seq_num}
 
-        # Create JSON and add checksum
+        # Create JSON and add CRC-16 checksum
         packet_json = json.dumps(packet_data, separators=(',', ':'))
-        checksum = hashlib.md5(packet_json.encode()).hexdigest()[:6]  # shortened checksum
-        packet_data['checksum'] = checksum
+        checksum = crc16_modbus(packet_json.encode('utf-8'))
+        packet_data['k'] = checksum # 'checksum' -> 'k'
 
         final_json = json.dumps(packet_data, separators=(',', ':'))
-        
+
         # Log the packet size for monitoring
         self.log_and_print(f"Packet size: {len(final_json)} bytes")
-        
+
         return final_json.encode()
 
     def verify_packet(self, packet_data):
-        """Verify packet checksum"""
+        """Verify packet CRC-16 checksum"""
         try:
-            data = json.loads(packet_data.decode())
-            checksum = data.pop('checksum', None)
+            # It's crucial to decode using 'utf-8' to match the sender's encoding
+            data = json.loads(packet_data.decode('utf-8'))
+            checksum = data.pop('k', None) # 'checksum' -> 'k'
             if not checksum:
+                self.log_and_print("RX: Packet failed verification: missing checksum 'k'")
                 return False, None
 
+            # Re-create the JSON string without the checksum to validate
             packet_json = json.dumps(data, separators=(',', ':'))
-            expected_checksum = hashlib.md5(packet_json.encode()).hexdigest()[:6]
+            expected_checksum = crc16_modbus(packet_json.encode('utf-8'))
 
             if checksum == expected_checksum:
-                data['checksum'] = checksum  # Put it back
+                data['k'] = checksum  # Add it back for logging/forwarding if needed
                 return True, data
             else:
+                self.log_and_print(f"RX: Packet failed verification: checksum mismatch. Got: {checksum}, Exp: {expected_checksum}")
                 return False, None
+        except (json.JSONDecodeError, UnicodeDecodeError) as e:
+            self.log_and_print(f"RX: Packet failed verification: could not decode JSON. Error: {e}")
+            return False, None
         except Exception as e:
+            self.log_and_print(f"RX: An unexpected error occurred during packet verification: {e}")
             return False, None
 
     def send_packet(self, packet_data):
@@ -676,46 +743,67 @@ class LoRaNode:
                     valid, packet_info = self.verify_packet(packet_data)
 
                     if valid:
-                        # Handle STORM_DATA packets (now using shortened format)
-                        if 'd' in packet_info and 'r' in packet_info:  # Shortened STORM_DATA packet
-                            self.log_and_print(f"RX: STORM_DATA packet Seq#{packet_info['seq']}")
-                            self.log_and_print(f"RX: Date: {packet_info.get('c_date')} {packet_info.get('c_time')}")
+                        seq_num = packet_info.get('s')
+                        if seq_num is None:
+                            self.log_and_print("RX: Invalid packet, missing sequence number 's'")
+                            self.update_stats('invalid_packets')
+                            continue
+
+                        # Handle STORM_DATA packets (new shortened format)
+                        if 'd' in packet_info and 'r' in packet_info:
+                            self.log_and_print(f"RX: STORM_DATA packet Seq#{seq_num}")
+
+                            # Reconstruct date/time for logging from compact format
+                            compact_ts = packet_info.get('t', '')
+                            csv_date, csv_time = "", ""
+                            if compact_ts:
+                                try:
+                                    dt_obj = datetime.strptime(compact_ts, "%y%m%d%H%M")
+                                    csv_date = dt_obj.strftime("%m/%d/%Y")
+                                    csv_time = dt_obj.strftime("%H:%M:%S")
+                                except ValueError:
+                                    self.log_and_print(f"RX: Could not parse compact timestamp '{compact_ts}'")
+
+                            self.log_and_print(f"RX: Timestamp: {csv_date} {csv_time}")
                             self.log_and_print(f"RX: River: {packet_info.get('d')}, Rain: {packet_info.get('r')}")
                             self.log_and_print(f"RX: Board Temp: {packet_info.get('T')}°C")
 
                             self.update_stats('packets_received')
 
-                            # Log to CSV
+                            # Log to CSV, maintaining the original format
                             try:
                                 with open(self.csv_path, "a") as f:
                                     ts = datetime.now().isoformat()
-                                    f.write(f"{ts},{packet_info['seq']},{packet_rssi},{noise_rssi},{snr},"
-                                            f"{packet_info.get('T', '')}"
-                                            f",\"{packet_info.get('c_date', '')}\",\"{packet_info.get('c_time', '')}\""
-                                            f",\"{packet_info.get('d', '')}\",\"{packet_info.get('r', '')}\""
-                                            f",\"{packet_info.get('ts', '')}\"\n")
+                                    # The old 'ts' field (tx_timestamp) from the packet is gone, log an empty string
+                                    f.write(f"{ts},{seq_num},{packet_rssi},{noise_rssi},{snr},"
+                                            f"{packet_info.get('T', '')},"
+                                            f"\"{csv_date}\",\"{csv_time}\","
+                                            f"\"{packet_info.get('d', '')}\",\"{packet_info.get('r', '')}\",\"\"\n")
                             except Exception as e:
                                 self.log_and_print(f"Failed to write to CSV log: {e}")
 
-                            # Send ACK using proven method
-                            ack_packet = self.create_packet('ACK', packet_info['seq'])
+                            # Send ACK
+                            ack_packet = self.create_packet('ACK', seq_num)
                             if self.send_packet(ack_packet):
-                                self.log_and_print(f"RX: ACK sent for Seq#{packet_info['seq']}")
+                                self.log_and_print(f"RX: ACK sent for Seq#{seq_num}")
                                 self.update_stats('acks_sent')
                             else:
-                                self.log_and_print(f"RX: Failed to send ACK for Seq#{packet_info['seq']}")
+                                self.log_and_print(f"RX: Failed to send ACK for Seq#{seq_num}")
 
-                        elif 'ack' in packet_info:  # ACK packet
-                            seq_num = packet_info['seq']
-                            if seq_num in self.pending_acks:
-                                self.log_and_print(f"RX: ACK received for Seq#{seq_num}")
-                                self.pending_acks.pop(seq_num)
-                                self.ack_received.set()
-                            else:
-                                self.log_and_print(f"RX: Unexpected ACK for Seq#{seq_num}")
+                        # Handle ACK packets (new shortened format)
+                        elif 'a' in packet_info:
+                            if self.mode == 'tx':  # Transmitter processes ACKs
+                                if seq_num in self.pending_acks:
+                                    self.log_and_print(f"RX: ACK received for Seq#{seq_num}")
+                                    self.pending_acks.pop(seq_num)
+                                    self.ack_received.set()
+                                else:
+                                    self.log_and_print(f"RX: Unexpected or late ACK for Seq#{seq_num}")
+                            else:  # Receiver got an ACK, which is unusual
+                                self.log_and_print(f"RX: Received an ACK packet (Seq#{seq_num}), but in RX-only mode.")
 
                     else:
-                        self.log_and_print(f"RX: Invalid packet received (checksum failure)")
+                        self.log_and_print(f"RX: Invalid packet received (checksum failure or malformed)")
                         self.update_stats('invalid_packets')
 
             except KeyboardInterrupt:


### PR DESCRIPTION
This commit refactors the LoRa packet structure to significantly reduce its size, addressing the user's packet-shortening plan.

The key changes include:
- Replaced the 6-char MD5 checksum with a 2-byte CRC-16/MODBUS checksum, represented as a 4-char hex string under the key 'k'.
- Removed redundant 'src_addr' and 'dst_addr' fields, as this information is already in the LoRa frame header.
- Replaced the 'ts' (local TX time) field and combined 'c_date' and 'c_time' into a single compact timestamp 't' with the format "YYMMDDHHmm".
- Converted 'riverstage' (d) and 'rain_gauge' (r) from strings to floating-point numbers with appropriate precision.
- Shortened all JSON keys to be single letters (s, t, d, r, T, k) to minimize overhead.

The `create_packet`, `verify_packet`, and receiver data handling logic have been updated to support the new, more efficient format.